### PR TITLE
Fix S3: `serve()` not implemented, MIME type not set when uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- S3 backend
+  - Fixed `serve()` is not implemented
+  - Fixed MIME type is not set when uploading objects
 
 ## 1.0.0 (2022-07-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- S3 backend
+- S3 backend [#2](https://github.com/etalab/flask-storage/pull/2)
   - Fixed `serve()` is not implemented
   - Fixed MIME type is not set when uploading objects
 

--- a/flask_storage/backends/s3.py
+++ b/flask_storage/backends/s3.py
@@ -3,7 +3,6 @@ import io
 import logging
 import mimetypes
 
-
 from contextlib import contextmanager
 
 import boto3

--- a/flask_storage/backends/s3.py
+++ b/flask_storage/backends/s3.py
@@ -1,12 +1,15 @@
 import codecs
 import io
 import logging
+import mimetypes
+
 
 from contextlib import contextmanager
 
 import boto3
 
 from botocore.exceptions import ClientError
+from flask import send_file
 
 from . import BaseBackend
 
@@ -66,7 +69,8 @@ class S3Backend(BaseBackend):
         return obj['Body'].read()
 
     def write(self, filename, content):
-        return self.bucket.put_object(Key=filename, Body=self.as_binary(content))
+        return self.bucket.put_object(Key=filename, Body=self.as_binary(content),
+                                      ContentType=mimetypes.guess_type(filename)[0])
 
     def delete(self, filename):
         for obj in self.bucket.objects.filter(Prefix=filename):
@@ -95,6 +99,6 @@ class S3Backend(BaseBackend):
             'modified': obj.last_modified,
         }
 
-    # def serve(self, filename):
-    #     file = self.fs.get_last_version(filename)
-    #     return send_file(file, mimetype=file.content_type)
+    def serve(self, filename):
+        with self.open(filename) as f:
+            return send_file(f, self.get_metadata(filename)['mime'])


### PR DESCRIPTION
This MR fixes two issues in S3 backend:

- missing implementation of `serve()` method
- missing MIME type setting when uploading objects, which leads to treating them as binary files