### PR TITLE
Use minimal dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     docker:
       - image: cimg/python:3.9.12
-      - image: circleci/mongo:3.6-stretch-ram
+      - image: mongo:6.0.4
       - image: minio/minio:RELEASE.2022-07-08T00-05-23Z
         environment:
           MINIO_ACCESS_KEY: ABCDEFGHIJKLMNOQRSTU

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   mongo:
-    image: mongo:3.6
+    image: mongo:6.0.4
     ports:
       - "27017:27017"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ authors = [{name = "Etalab", email = "etalab@data.gouv.fr"}]
 readme = "README.md"
 dynamic = ["version", "description"]
 dependencies = [
-    "Flask==2.1.2",
-    "flask-mongoengine==1.0.0",
-    "Pillow==9.2.0",
-    "boto3==1.26.102",
-    "markupsafe==2.1.2"
+    "Flask>=2.2.5",
+    "flask-mongoengine>=1.0.0",
+    "Pillow>=9.2.0",
+    "boto3>=1.26.102",
+    "markupsafe>=2.1.2"
 ]
 
 [project.optional-dependencies]
@@ -21,11 +21,11 @@ dev = [
     "flit==3.6.0"
 ]
 test = [
-    "pytest==7.1.2",
+    "pytest==8.3.5",
     "pytest-faker==2.0.0",
-    "pytest-flask==1.2.0",
-    "pytest-sugar==0.9.4",
-    "pytest-mock==3.8.2",
+    "pytest-flask==1.3.0",
+    "pytest-sugar==1.0.0",
+    "pytest-mock==3.14.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,12 @@ authors = [{name = "Etalab", email = "etalab@data.gouv.fr"}]
 readme = "README.md"
 dynamic = ["version", "description"]
 dependencies = [
-    "Flask==2.2.5",
+    "Flask>=2.1.2",
     "flask-mongoengine>=1.0.0",
     "Pillow>=9.2.0",
     "boto3>=1.26.102",
-    "markupsafe>=2.1.2"
+    "markupsafe>=2.1.2",
+    "werkzeug==2.2.3"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{name = "Etalab", email = "etalab@data.gouv.fr"}]
 readme = "README.md"
 dynamic = ["version", "description"]
 dependencies = [
-    "Flask>=2.2.5",
+    "Flask==2.2.5",
     "flask-mongoengine>=1.0.0",
     "Pillow>=9.2.0",
     "boto3>=1.26.102",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dev = [
 ]
 test = [
     "pytest==8.3.5",
-    "pytest-faker==2.0.0",
+    "factory-boy==3.3.3",
+    "faker==37.1.0",
     "pytest-flask==1.3.0",
     "pytest-sugar==1.0.0",
     "pytest-mock==3.14.0",


### PR DESCRIPTION
Needed for further Flask & all upgrades following https://github.com/opendatateam/udata/pull/3278

Indeed, it hard pins some dependencies and prevent upgraded those in udata.
We loose those dependencies in this PR.