### PR TITLE
Feat(S3): add optional s3 extra args when pushing objects

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -91,6 +91,8 @@ Here an example configuration with local files storages and s3 images storage:
     # storage specific configuration
     AVATARS_FS_BACKEND = 's3'
     AVATARS_FS_BUCKET_NAME = 'avatars-bucket'  # optionnal, default to storage name
+    AVATARS_FS_OBJECT_ACL = 'public-read'  # some S3 providers need to specify the ACL at the object level
+    AVATARS_FS_OBJECT_STORAGE_CLASS = 'STANDARD'  # specify the object storage class
     IMAGES_FS_BACKEND = 's3'
     FILES_FS_URL = 'https://images.somewhere.com/'
     FILES_FS_URL = 'https://files.somewhere.com/'

--- a/flask_storage/backends/s3.py
+++ b/flask_storage/backends/s3.py
@@ -66,24 +66,18 @@ class S3Backend(BaseBackend):
         else:  # mode == 'w'
             f = io.BytesIO() if 'b' in mode else io.StringIO()
             yield f
-            obj.put(Body=f.getvalue())
+            obj.put(Body=f.getvalue(), **self.get_object_extra_args())
 
     def read(self, filename):
         obj = self.bucket.Object(filename).get()
         return obj['Body'].read()
 
     def write(self, filename, content):
-        # Build extra args for options present in config
-        extra_args = {
-            arg_name: self.config[config_key]
-            for config_key, arg_name in self._S3_OBJECT_OPTION_MAP.items()
-            if config_key in self.config
-        }
         return self.bucket.put_object(
             Key=filename,
             Body=self.as_binary(content),
             ContentType=mimetypes.guess_type(filename)[0],
-            **extra_args,
+            **self.get_object_extra_args(),
         )
 
     def delete(self, filename):
@@ -116,3 +110,11 @@ class S3Backend(BaseBackend):
     def serve(self, filename):
         with self.open(filename, mode="rb") as f:
             return send_file(f, self.get_metadata(filename)['mime'])
+
+    def get_object_extra_args(self):
+        # Build extra args for options present in config
+        return {
+            arg_name: self.config[config_key]
+            for config_key, arg_name in self._S3_OBJECT_OPTION_MAP.items()
+            if config_key in self.config
+        }

--- a/flask_storage/backends/s3.py
+++ b/flask_storage/backends/s3.py
@@ -26,6 +26,12 @@ class S3Backend(BaseBackend):
     - `access_key`: The AWS credential access key
     - `secret_key`: The AWS credential secret key
     '''
+
+    _S3_OBJECT_OPTION_MAP = {
+        "object_acl": "ACL",
+        "object_storage_class": "StorageClass",
+    }
+
     def __init__(self, name, config):
         super().__init__(name, config)
 
@@ -67,8 +73,18 @@ class S3Backend(BaseBackend):
         return obj['Body'].read()
 
     def write(self, filename, content):
-        return self.bucket.put_object(Key=filename, Body=self.as_binary(content),
-                                      ContentType=mimetypes.guess_type(filename)[0])
+        # Build extra args for options present in config
+        extra_args = {
+            arg_name: self.config[config_key]
+            for config_key, arg_name in self._S3_OBJECT_OPTION_MAP.items()
+            if self.config.get(config_key)
+        }
+        return self.bucket.put_object(
+            Key=filename,
+            Body=self.as_binary(content),
+            ContentType=mimetypes.guess_type(filename)[0],
+            **extra_args,
+        )
 
     def delete(self, filename):
         for obj in self.bucket.objects.filter(Prefix=filename):

--- a/flask_storage/backends/s3.py
+++ b/flask_storage/backends/s3.py
@@ -77,7 +77,7 @@ class S3Backend(BaseBackend):
         extra_args = {
             arg_name: self.config[config_key]
             for config_key, arg_name in self._S3_OBJECT_OPTION_MAP.items()
-            if self.config.get(config_key)
+            if config_key in self.config
         }
         return self.bucket.put_object(
             Key=filename,


### PR DESCRIPTION
Related to https://github.com/datagouv/data.gouv.fr/issues/1933.

Example for storage `avatars`:
```
AVATARS_FS_OBJECT_ACL = 'public-read'  # some S3 providers need to specify the ACL at the object level
AVATARS_FS_OBJECT_STORAGE_CLASS = 'STANDARD'  # specify the object storage class
```