### PR TITLE
fix(s3): fix content type if not guessed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- fix(s3): fix content type if not guessed [#18](https://github.com/etalab/flask-storage/pull/18)
 
 ## 1.4.4 (2026-03-12)
 

--- a/flask_storage/backends/s3.py
+++ b/flask_storage/backends/s3.py
@@ -73,11 +73,13 @@ class S3Backend(BaseBackend):
         return obj['Body'].read()
 
     def write(self, filename, content):
+        extra_args = self.get_object_extra_args()
+        if content_type:= mimetypes.guess_type(filename)[0]:
+            extra_args["ContentType"] = content_type
         return self.bucket.put_object(
             Key=filename,
             Body=self.as_binary(content),
-            ContentType=mimetypes.guess_type(filename)[0],
-            **self.get_object_extra_args(),
+            **extra_args
         )
 
     def delete(self, filename):


### PR DESCRIPTION
Fix
```
  File "udata/.venv/lib/python3.12/site-packages/flask_storage/storage.py", line 299, in save
    self.backend.save(file_or_wfs, filename)
  File "udata/.venv/lib/python3.12/site-packages/flask_storage/backends/__init__.py", line 64, in save
    self.write(filename, file_or_wfs.read())
  File "udata/.venv/lib/python3.12/site-packages/flask_storage/backends/s3.py", line 80, in write
    return self.bucket.put_object(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "udata/.venv/lib/python3.12/site-packages/boto3/resources/factory.py", line 581, in do_action
    response = action(self, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "udata/.venv/lib/python3.12/site-packages/boto3/resources/action.py", line 88, in __call__
    response = getattr(parent.meta.client, operation_name)(*args, **params)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "udata/.venv/lib/python3.12/site-packages/botocore/client.py", line 606, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "udata/.venv/lib/python3.12/site-packages/botocore/context.py", line 123, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "udata/.venv/lib/python3.12/site-packages/botocore/client.py", line 1051, in _make_api_call
    request_dict = self._convert_to_request_dict(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "udata/.venv/lib/python3.12/site-packages/botocore/client.py", line 1118, in _convert_to_request_dict
    request_dict = self._serializer.serialize_to_request(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "udata/.venv/lib/python3.12/site-packages/botocore/validate.py", line 424, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter ContentType, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
```