### PR TITLE
fix: do not deep copy the storage when mongoengine copies a FileField

### DIFF
--- a/flask_storage/mongo.py
+++ b/flask_storage/mongo.py
@@ -222,16 +222,6 @@ class FileField(BaseField):
         self.basename = basename
         super().__init__(*args, **kwargs)
 
-    def __deepcopy__(self, memo):
-        # A field holds a reference to the application `Storage`, hence to its
-        # backend — which, on S3, owns boto3 clients that recurse forever when
-        # copied. Mongoengine deep-copies a document's fields whenever
-        # auto-dereferencing is off (`no_dereference()`), so copy the field
-        # itself but keep pointing at the same storage.
-        copied = self.__class__.__new__(self.__class__)
-        copied.__dict__.update(self.__dict__)
-        return copied
-
     def proxy(self, filename=None, instance=None, **kwargs):
         return self.proxy_class(
             fs=self.fs,

--- a/flask_storage/mongo.py
+++ b/flask_storage/mongo.py
@@ -222,6 +222,16 @@ class FileField(BaseField):
         self.basename = basename
         super().__init__(*args, **kwargs)
 
+    def __deepcopy__(self, memo):
+        # A field holds a reference to the application `Storage`, hence to its
+        # backend — which, on S3, owns boto3 clients that recurse forever when
+        # copied. Mongoengine deep-copies a document's fields whenever
+        # auto-dereferencing is off (`no_dereference()`), so copy the field
+        # itself but keep pointing at the same storage.
+        copied = self.__class__.__new__(self.__class__)
+        copied.__dict__.update(self.__dict__)
+        return copied
+
     def proxy(self, filename=None, instance=None, **kwargs):
         return self.proxy_class(
             fs=self.fs,

--- a/flask_storage/storage.py
+++ b/flask_storage/storage.py
@@ -82,6 +82,15 @@ class Storage:
         self.backend = None
         self.overwrite = overwrite
 
+    def __deepcopy__(self, memo):
+        # A storage is a single application-wide object, registered once on the
+        # app: nothing ever needs a duplicate of one. Copying it would clone its
+        # backend too, and the S3 backend owns boto3 clients, which recurse
+        # until the stack blows when deep-copied. Mongoengine reaches us that
+        # way: it deep-copies a document's fields whenever auto-dereferencing is
+        # off, and those fields point here.
+        return self
+
     def configure(self, app):
         """
         Load configuration from application configuration.

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -7,27 +7,23 @@ from flask_storage.mongo import FileField, ImageField
 
 
 @pytest.fixture(params=[FileField, ImageField])
-def field(request, app, mock_backend):
-    storage = fs.Storage("test")
-    app.configure(storage)
-    return request.param(fs=storage)
+def field(request):
+    return request.param(fs=fs.Storage("test"))
 
 
-def test_deepcopy_shares_the_storage(field):
+def test_deepcopy_of_a_field_shares_the_storage(field):
     # Mongoengine deep-copies a document's fields whenever auto-dereferencing
-    # is off. The storage — and the backend it owns, which holds network
-    # clients on S3 — must be shared with the copy, never copied.
+    # is off, and every field points at the application storage.
     copied = copy.deepcopy(field)
 
     assert copied.fs is field.fs
-    assert copied.fs.backend is field.fs.backend
 
 
-def test_deepcopy_is_a_distinct_field(field):
-    # Turning dereferencing off is done by mutating the copy, so the copy must
-    # not be the class-level field itself: that would leak across documents.
-    copied = copy.deepcopy(field)
-    copied.set_auto_dereferencing(False)
+def test_deepcopy_of_a_file_reference_shares_the_storage(field):
+    # The proxies stored in `document._data` hold the storage too, so deep
+    # copying a document must not duplicate it either.
+    reference = field.proxy(filename="file.test")
 
-    assert copied is not field
-    assert field._auto_dereference
+    copied = copy.deepcopy(reference)
+
+    assert copied.fs is field.fs

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -1,0 +1,33 @@
+import copy
+
+import pytest
+
+import flask_storage as fs
+from flask_storage.mongo import FileField, ImageField
+
+
+@pytest.fixture(params=[FileField, ImageField])
+def field(request, app, mock_backend):
+    storage = fs.Storage("test")
+    app.configure(storage)
+    return request.param(fs=storage)
+
+
+def test_deepcopy_shares_the_storage(field):
+    # Mongoengine deep-copies a document's fields whenever auto-dereferencing
+    # is off. The storage — and the backend it owns, which holds network
+    # clients on S3 — must be shared with the copy, never copied.
+    copied = copy.deepcopy(field)
+
+    assert copied.fs is field.fs
+    assert copied.fs.backend is field.fs.backend
+
+
+def test_deepcopy_is_a_distinct_field(field):
+    # Turning dereferencing off is done by mutating the copy, so the copy must
+    # not be the class-level field itself: that would leak across documents.
+    copied = copy.deepcopy(field)
+    copied.set_auto_dereferencing(False)
+
+    assert copied is not field
+    assert field._auto_dereference


### PR DESCRIPTION
Loading a document with `no_dereference()` returned a 500 whenever the model had a FileField or an ImageField and the storage used the S3 backend:

    RecursionError: maximum recursion depth exceeded
      botocore/client.py, in __getattr__
      botocore/client.py, in _service_model
